### PR TITLE
Update to @foxglove/xmlrpc 1.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   "dependencies": {
     "@foxglove/rosmsg": "^2.0.0 || ^3.0.0",
     "@foxglove/rosmsg-serialization": "^1.2.3",
-    "@foxglove/xmlrpc": "^1.1.4",
+    "@foxglove/xmlrpc": "^1.1.5",
     "eventemitter3": "^4.0.7"
   }
 }

--- a/src/RosXmlRpcClient.ts
+++ b/src/RosXmlRpcClient.ts
@@ -6,7 +6,7 @@ export class RosXmlRpcClient {
   private _client: XmlRpcClient;
 
   constructor(url: string) {
-    this._client = new XmlRpcClient(url, { encoding: "utf8" });
+    this._client = new XmlRpcClient(url, { encoding: "utf-8" });
   }
 
   url(): string {

--- a/yarn.lock
+++ b/yarn.lock
@@ -358,10 +358,10 @@
   dependencies:
     md5-typescript "^1.0.5"
 
-"@foxglove/xmlrpc@^1.1.4":
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/@foxglove/xmlrpc/-/xmlrpc-1.1.4.tgz#63b2cdb2d1787788be87a87e433de9406b5e7a75"
-  integrity sha512-XkudpVbKKTxfnnl9tNqU5aahdzJ/9FCgWiLy+5BXYgvH8YXVu89UsRaO/uALLf4fZ2HhKpOSMGbV77rT1I592Q==
+"@foxglove/xmlrpc@^1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@foxglove/xmlrpc/-/xmlrpc-1.1.5.tgz#07047d5dea35aa612db5cea5725f11139081eaea"
+  integrity sha512-snjQrhlfUukDDO7fwXzapUO5DeVpqqPbk8K08Ra6pcCi40vdrLL3xe8N6q4WlCf1t78tXnXJm/VdZe6zgec+6Q==
   dependencies:
     "@foxglove/just-fetch" "^1.2.4"
     byte-base64 "^1.1.0"


### PR DESCRIPTION
This sets the encoding to "utf-8" instead of "utf8", which is more widely accepted as a valid encoding and fixes compatibility with goroslib. See https://github.com/foxglove/studio/issues/2072