### PR TITLE
Improve local handling of parameter updates.

### DIFF
--- a/src/RosNode.ts
+++ b/src/RosNode.ts
@@ -283,6 +283,10 @@ export class RosNode extends EventEmitter<RosNodeEvents> {
     if (status !== OK) {
       throw new Error(`setParam returned failure (status=${status}): ${msg}`);
     }
+
+    // Also do a local update because ROS param server won't notify us if
+    // we initiated the parameter update.
+    this._handleParamUpdate(key, value, this.name);
   }
 
   async subscribeParam(key: string): Promise<XmlRpcValue> {


### PR DESCRIPTION
**Public-Facing Changes**
<!-- describe any changes to the public interface or APIs, or write "None" -->
This improves the handling of parameter updates.

**Description**
<!-- describe what has changed, and motivation behind those changes -->
The ROS parameter server will not send parameter update messages back to the node that initiated the parameter change so this handle that by propagating the update event once we confirm the value has been successfully updated on the parameter server.

<!-- link relevant GitHub issues -->
