### PR TITLE
Fix bug with multiple subscribers.

### DIFF
--- a/src/Publication.ts
+++ b/src/Publication.ts
@@ -62,7 +62,9 @@ export class Publication {
     const tasks: Promise<void>[] = [];
     for (const sub of this._subscribers.values()) {
       if (sub.client.transportType() === transportType) {
-        tasks.push(sub.client.write(data));
+        // A defensive copy of the data is needed here. The
+        // source data array gets "detached".
+        tasks.push(sub.client.write(new Uint8Array(data)));
       }
     }
     await Promise.allSettled(tasks);


### PR DESCRIPTION
**Public-Facing Changes**
This fixes an issue with publishing to multiple subscribers.

**Description**
It seems that the data array passed to `Publication.write` gets "detached" so we need to make a defensive copy.


<!-- link relevant GitHub issues -->
