### PR TITLE
Fix publishing to roscpp nodes, add publishing example

### DIFF
--- a/examples/ros1-chatter/.eslintrc.yaml
+++ b/examples/ros1-chatter/.eslintrc.yaml
@@ -1,0 +1,2 @@
+parserOptions:
+  project: examples/ros1-chatter/tsconfig.json

--- a/examples/ros1-chatter/package.json
+++ b/examples/ros1-chatter/package.json
@@ -26,6 +26,6 @@
     "typescript": "4.5.2"
   },
   "dependencies": {
-    "@foxglove/ros1": "file:../../"
+    "@foxglove/ros1": "file:../.."
   }
 }

--- a/examples/ros1-chatter/package.json
+++ b/examples/ros1-chatter/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "ros1-turtlesim-test",
+  "name": "ros1-chatter",
   "version": "0.0.0",
-  "description": "Example @foxglove/ros1 client that interacts with turtlesim",
+  "description": "Example @foxglove/ros1 client that publishes to /chatter",
   "license": "MIT",
   "private": true,
   "repository": {

--- a/examples/ros1-chatter/package.json
+++ b/examples/ros1-chatter/package.json
@@ -26,6 +26,6 @@
     "typescript": "4.5.2"
   },
   "dependencies": {
-    "@foxglove/ros1": "file:../../"
+    "@foxglove/ros1": "latest"
   }
 }

--- a/examples/ros1-chatter/package.json
+++ b/examples/ros1-chatter/package.json
@@ -26,6 +26,6 @@
     "typescript": "4.5.2"
   },
   "dependencies": {
-    "@foxglove/ros1": "latest"
+    "@foxglove/ros1": "file:../../"
   }
 }

--- a/examples/ros1-chatter/src/index.ts
+++ b/examples/ros1-chatter/src/index.ts
@@ -1,0 +1,58 @@
+import { RosNode } from "@foxglove/ros1";
+import {
+  TcpServerNode,
+  TcpSocketNode,
+  getEnvVar,
+  getPid,
+  getHostname,
+  getNetworkInterfaces,
+} from "@foxglove/ros1/nodejs";
+import { HttpServerNodejs } from "@foxglove/xmlrpc/nodejs";
+
+async function main() {
+  const name = "/ros1-chatter";
+  let rosNode: RosNode | undefined;
+
+  try {
+    const hostname = RosNode.GetRosHostname(getEnvVar, getHostname, getNetworkInterfaces);
+    const tcpServer = await TcpServerNode.Listen({ host: hostname });
+    rosNode = new RosNode({
+      name,
+      rosMasterUri: getEnvVar("ROS_MASTER_URI") ?? "http://localhost:11311/",
+      hostname,
+      pid: getPid(),
+      httpServer: new HttpServerNodejs(),
+      tcpSocketCreate: TcpSocketNode.Create,
+      tcpServer,
+      log: console,
+    });
+
+    await rosNode.start();
+
+    await rosNode.advertise({
+      topic: "/chatter",
+      dataType: "std_msgs/String",
+      latching: true,
+      messageDefinition: [{ definitions: [{ name: "data", type: "string" }] }],
+      messageDefinitionText: "string data",
+      md5sum: "992ce8a1687cec8c8bd883ec73ca41d1",
+    });
+
+    let running = true;
+    process.on("SIGINT", () => (running = false));
+
+    while (running) {
+      void rosNode.publish("/chatter", { data: "Hello, world!" });
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+
+    rosNode.shutdown();
+  } catch (err) {
+    const msg = (err as Error).stack ?? `${err}`;
+    console.error(msg);
+  } finally {
+    rosNode?.shutdown();
+  }
+}
+
+void main();

--- a/examples/ros1-chatter/src/index.ts
+++ b/examples/ros1-chatter/src/index.ts
@@ -45,8 +45,6 @@ async function main() {
       void rosNode.publish("/chatter", { data: "Hello, world!" });
       await new Promise((resolve) => setTimeout(resolve, 1000));
     }
-
-    rosNode.shutdown();
   } catch (err) {
     const msg = (err as Error).stack ?? `${err}`;
     console.error(msg);

--- a/examples/ros1-chatter/tsconfig.json
+++ b/examples/ros1-chatter/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*.ts"],
+  "compilerOptions": {
+    "outDir": "dist",
+    "target": "es2020",
+    "module": "commonjs",
+    "lib": ["es2020"],
+    "importHelpers": true,
+    "downlevelIteration": true,
+    "declaration": true,
+    "rootDir": "./src",
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noEmit": true
+  }
+}

--- a/examples/ros1-chatter/yarn.lock
+++ b/examples/ros1-chatter/yarn.lock
@@ -38,9 +38,9 @@
     eventemitter3 "^4.0.7"
 
 "@foxglove/rosmsg-serialization@^1.2.3":
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/@foxglove/rosmsg-serialization/-/rosmsg-serialization-1.2.3.tgz#742adc7a322357b0a19aaebb4fe7c2c557f55e92"
-  integrity sha512-wXYqEtcJAXjJEKxxB18tx/3bbI2peQdbqzIWYnCCf9VwVDLk57O/fGqHLJnH5hUH4I37khE/Q0xU/JXSUrp46A==
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@foxglove/rosmsg-serialization/-/rosmsg-serialization-1.3.0.tgz#09df28ada98e117f71ed4f63e4ffee179d8a726e"
+  integrity sha512-8at2IJOU9BrQ4PkDfbBXY5AU0SA9iXTQPfa6M0GEwDajjsl3J7SChJjoncDvNqW5UlcDIiqZg6r2EGs4imVIwQ==
   dependencies:
     "@foxglove/rosmsg" "^2.0.0 || ^3.0.0"
 
@@ -111,9 +111,9 @@
   integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
 
 "@types/node@*":
-  version "16.11.7"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.7.tgz#36820945061326978c42a01e56b61cd223dfdc42"
-  integrity sha512-QB5D2sqfSjCmTuWcBWyJ+/44bcjO7VbjSbOE0ucoVbAsSNQc4Lt6QkgkVXkTDwkL4z/beecZNDvVX15D4P8Jbw==
+  version "17.0.23"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.23.tgz#3b41a6e643589ac6442bdbd7a4a3ded62f33f7da"
+  integrity sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==
 
 acorn-walk@^8.1.1:
   version "8.2.0"

--- a/examples/ros1-chatter/yarn.lock
+++ b/examples/ros1-chatter/yarn.lock
@@ -34,7 +34,7 @@
   dependencies:
     "@foxglove/rosmsg" "^2.0.0 || ^3.0.0"
     "@foxglove/rosmsg-serialization" "^1.2.3"
-    "@foxglove/xmlrpc" "^1.1.8"
+    "@foxglove/xmlrpc" "^1.1.9"
     eventemitter3 "^4.0.7"
 
 "@foxglove/rosmsg-serialization@^1.2.3":
@@ -51,10 +51,10 @@
   dependencies:
     md5-typescript "^1.0.5"
 
-"@foxglove/xmlrpc@^1.1.8":
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/@foxglove/xmlrpc/-/xmlrpc-1.1.8.tgz#95512d38fc0aef32f5de9023c86432f449e385f6"
-  integrity sha512-BrEdB45FJ/Tilk9utSV2Gn1GTB2Z/699UoO7PN/ZyCtENAVv7hK9W3hxxdoGAM+xP9/7bI8HjZxzo5OSwELSmg==
+"@foxglove/xmlrpc@^1.1.9":
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/@foxglove/xmlrpc/-/xmlrpc-1.1.9.tgz#15d338f585b538865c0a281d2787a4204721389e"
+  integrity sha512-Lf49vDIh3ewAEtYqI7IeczLfxC4YHRqyavE613KlOoPkBvVrkkjco4lJuFKiSNd0AieJN9D2GV3vZpe5sa2/Cw==
   dependencies:
     "@foxglove/just-fetch" "^1.2.4"
     byte-base64 "^1.1.0"

--- a/examples/ros1-chatter/yarn.lock
+++ b/examples/ros1-chatter/yarn.lock
@@ -29,8 +29,10 @@
     data-uri-to-buffer "^3.0.1"
     fetch-blob "^2.1.1"
 
-"@foxglove/ros1@file:../..":
+"@foxglove/ros1@latest":
   version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@foxglove/ros1/-/ros1-1.4.0.tgz#20a870461127b0014273a6a4456c7a21ed06000e"
+  integrity sha512-SQg23SMLgm2gSXEDNrQLShDp5N38UdxJYYEj0vWILXIGZCxfLxctCgJPgYPeNdGNHx+w6TNtMg1uWfTOl4CxBw==
   dependencies:
     "@foxglove/rosmsg" "^2.0.0 || ^3.0.0"
     "@foxglove/rosmsg-serialization" "^1.2.3"

--- a/examples/ros1-chatter/yarn.lock
+++ b/examples/ros1-chatter/yarn.lock
@@ -29,14 +29,12 @@
     data-uri-to-buffer "^3.0.1"
     fetch-blob "^2.1.1"
 
-"@foxglove/ros1@latest":
+"@foxglove/ros1@file:../..":
   version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@foxglove/ros1/-/ros1-1.4.0.tgz#20a870461127b0014273a6a4456c7a21ed06000e"
-  integrity sha512-SQg23SMLgm2gSXEDNrQLShDp5N38UdxJYYEj0vWILXIGZCxfLxctCgJPgYPeNdGNHx+w6TNtMg1uWfTOl4CxBw==
   dependencies:
     "@foxglove/rosmsg" "^2.0.0 || ^3.0.0"
     "@foxglove/rosmsg-serialization" "^1.2.3"
-    "@foxglove/xmlrpc" "^1.1.6"
+    "@foxglove/xmlrpc" "^1.1.8"
     eventemitter3 "^4.0.7"
 
 "@foxglove/rosmsg-serialization@^1.2.3":
@@ -53,10 +51,10 @@
   dependencies:
     md5-typescript "^1.0.5"
 
-"@foxglove/xmlrpc@^1.1.6":
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/@foxglove/xmlrpc/-/xmlrpc-1.1.6.tgz#29e5cf8f38641b8629946381e3cfe22f9c1cab77"
-  integrity sha512-R6JMgJUtltvoyxdjk1zG9C3d092ABAcxRmwjUsdh/xNowNiB9sOKtzn4SctuBFEi+fME6x53SO/2U6hu5rZTPg==
+"@foxglove/xmlrpc@^1.1.8":
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/@foxglove/xmlrpc/-/xmlrpc-1.1.8.tgz#95512d38fc0aef32f5de9023c86432f449e385f6"
+  integrity sha512-BrEdB45FJ/Tilk9utSV2Gn1GTB2Z/699UoO7PN/ZyCtENAVv7hK9W3hxxdoGAM+xP9/7bI8HjZxzo5OSwELSmg==
   dependencies:
     "@foxglove/just-fetch" "^1.2.4"
     byte-base64 "^1.1.0"

--- a/examples/ros1-turtlesim-test/package.json
+++ b/examples/ros1-turtlesim-test/package.json
@@ -26,6 +26,6 @@
     "typescript": "4.5.2"
   },
   "dependencies": {
-    "@foxglove/ros1": "file:../../"
+    "@foxglove/ros1": "file:../.."
   }
 }

--- a/examples/ros1-turtlesim-test/package.json
+++ b/examples/ros1-turtlesim-test/package.json
@@ -26,6 +26,6 @@
     "typescript": "4.5.2"
   },
   "dependencies": {
-    "@foxglove/ros1": "file:../../"
+    "@foxglove/ros1": "latest"
   }
 }

--- a/examples/ros1-turtlesim-test/package.json
+++ b/examples/ros1-turtlesim-test/package.json
@@ -26,6 +26,6 @@
     "typescript": "4.5.2"
   },
   "dependencies": {
-    "@foxglove/ros1": "latest"
+    "@foxglove/ros1": "file:../../"
   }
 }

--- a/examples/ros1-turtlesim-test/yarn.lock
+++ b/examples/ros1-turtlesim-test/yarn.lock
@@ -29,20 +29,18 @@
     data-uri-to-buffer "^3.0.1"
     fetch-blob "^2.1.1"
 
-"@foxglove/ros1@latest":
+"@foxglove/ros1@file:../..":
   version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@foxglove/ros1/-/ros1-1.4.0.tgz#20a870461127b0014273a6a4456c7a21ed06000e"
-  integrity sha512-SQg23SMLgm2gSXEDNrQLShDp5N38UdxJYYEj0vWILXIGZCxfLxctCgJPgYPeNdGNHx+w6TNtMg1uWfTOl4CxBw==
   dependencies:
     "@foxglove/rosmsg" "^2.0.0 || ^3.0.0"
     "@foxglove/rosmsg-serialization" "^1.2.3"
-    "@foxglove/xmlrpc" "^1.1.6"
+    "@foxglove/xmlrpc" "^1.1.8"
     eventemitter3 "^4.0.7"
 
 "@foxglove/rosmsg-serialization@^1.2.3":
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/@foxglove/rosmsg-serialization/-/rosmsg-serialization-1.2.3.tgz#742adc7a322357b0a19aaebb4fe7c2c557f55e92"
-  integrity sha512-wXYqEtcJAXjJEKxxB18tx/3bbI2peQdbqzIWYnCCf9VwVDLk57O/fGqHLJnH5hUH4I37khE/Q0xU/JXSUrp46A==
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@foxglove/rosmsg-serialization/-/rosmsg-serialization-1.3.0.tgz#09df28ada98e117f71ed4f63e4ffee179d8a726e"
+  integrity sha512-8at2IJOU9BrQ4PkDfbBXY5AU0SA9iXTQPfa6M0GEwDajjsl3J7SChJjoncDvNqW5UlcDIiqZg6r2EGs4imVIwQ==
   dependencies:
     "@foxglove/rosmsg" "^2.0.0 || ^3.0.0"
 
@@ -53,10 +51,10 @@
   dependencies:
     md5-typescript "^1.0.5"
 
-"@foxglove/xmlrpc@^1.1.6":
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/@foxglove/xmlrpc/-/xmlrpc-1.1.6.tgz#29e5cf8f38641b8629946381e3cfe22f9c1cab77"
-  integrity sha512-R6JMgJUtltvoyxdjk1zG9C3d092ABAcxRmwjUsdh/xNowNiB9sOKtzn4SctuBFEi+fME6x53SO/2U6hu5rZTPg==
+"@foxglove/xmlrpc@^1.1.8":
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/@foxglove/xmlrpc/-/xmlrpc-1.1.8.tgz#95512d38fc0aef32f5de9023c86432f449e385f6"
+  integrity sha512-BrEdB45FJ/Tilk9utSV2Gn1GTB2Z/699UoO7PN/ZyCtENAVv7hK9W3hxxdoGAM+xP9/7bI8HjZxzo5OSwELSmg==
   dependencies:
     "@foxglove/just-fetch" "^1.2.4"
     byte-base64 "^1.1.0"
@@ -113,9 +111,9 @@
   integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
 
 "@types/node@*":
-  version "16.11.7"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.7.tgz#36820945061326978c42a01e56b61cd223dfdc42"
-  integrity sha512-QB5D2sqfSjCmTuWcBWyJ+/44bcjO7VbjSbOE0ucoVbAsSNQc4Lt6QkgkVXkTDwkL4z/beecZNDvVX15D4P8Jbw==
+  version "17.0.23"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.23.tgz#3b41a6e643589ac6442bdbd7a4a3ded62f33f7da"
+  integrity sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==
 
 acorn-walk@^8.1.1:
   version "8.2.0"

--- a/examples/ros1-turtlesim-test/yarn.lock
+++ b/examples/ros1-turtlesim-test/yarn.lock
@@ -34,7 +34,7 @@
   dependencies:
     "@foxglove/rosmsg" "^2.0.0 || ^3.0.0"
     "@foxglove/rosmsg-serialization" "^1.2.3"
-    "@foxglove/xmlrpc" "^1.1.8"
+    "@foxglove/xmlrpc" "^1.1.9"
     eventemitter3 "^4.0.7"
 
 "@foxglove/rosmsg-serialization@^1.2.3":
@@ -51,10 +51,10 @@
   dependencies:
     md5-typescript "^1.0.5"
 
-"@foxglove/xmlrpc@^1.1.8":
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/@foxglove/xmlrpc/-/xmlrpc-1.1.8.tgz#95512d38fc0aef32f5de9023c86432f449e385f6"
-  integrity sha512-BrEdB45FJ/Tilk9utSV2Gn1GTB2Z/699UoO7PN/ZyCtENAVv7hK9W3hxxdoGAM+xP9/7bI8HjZxzo5OSwELSmg==
+"@foxglove/xmlrpc@^1.1.9":
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/@foxglove/xmlrpc/-/xmlrpc-1.1.9.tgz#15d338f585b538865c0a281d2787a4204721389e"
+  integrity sha512-Lf49vDIh3ewAEtYqI7IeczLfxC4YHRqyavE613KlOoPkBvVrkkjco4lJuFKiSNd0AieJN9D2GV3vZpe5sa2/Cw==
   dependencies:
     "@foxglove/just-fetch" "^1.2.4"
     byte-base64 "^1.1.0"

--- a/examples/ros1-turtlesim-test/yarn.lock
+++ b/examples/ros1-turtlesim-test/yarn.lock
@@ -29,8 +29,10 @@
     data-uri-to-buffer "^3.0.1"
     fetch-blob "^2.1.1"
 
-"@foxglove/ros1@file:../..":
+"@foxglove/ros1@latest":
   version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@foxglove/ros1/-/ros1-1.4.0.tgz#20a870461127b0014273a6a4456c7a21ed06000e"
+  integrity sha512-SQg23SMLgm2gSXEDNrQLShDp5N38UdxJYYEj0vWILXIGZCxfLxctCgJPgYPeNdGNHx+w6TNtMg1uWfTOl4CxBw==
   dependencies:
     "@foxglove/rosmsg" "^2.0.0 || ^3.0.0"
     "@foxglove/rosmsg-serialization" "^1.2.3"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "@foxglove/rosmsg": "^2.0.0 || ^3.0.0",
     "@foxglove/rosmsg-serialization": "^1.2.3",
-    "@foxglove/xmlrpc": "^1.1.6",
+    "@foxglove/xmlrpc": "^1.1.7",
     "eventemitter3": "^4.0.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "@foxglove/rosmsg": "^2.0.0 || ^3.0.0",
     "@foxglove/rosmsg-serialization": "^1.2.3",
-    "@foxglove/xmlrpc": "^1.1.7",
+    "@foxglove/xmlrpc": "^1.1.8",
     "eventemitter3": "^4.0.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "@foxglove/rosmsg": "^2.0.0 || ^3.0.0",
     "@foxglove/rosmsg-serialization": "^1.2.3",
-    "@foxglove/xmlrpc": "^1.1.8",
+    "@foxglove/xmlrpc": "^1.1.9",
     "eventemitter3": "^4.0.7"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -358,10 +358,10 @@
   dependencies:
     md5-typescript "^1.0.5"
 
-"@foxglove/xmlrpc@^1.1.7":
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/@foxglove/xmlrpc/-/xmlrpc-1.1.7.tgz#ddda571dcaec73c96d3e718b34ffc14d3374fd0b"
-  integrity sha512-t7g+YgWD2U+AwqfCsPD/IxmJZFxeFF1PMhsjpZUahXCOMHoLbkI4GftPKX/IiFCBD8Cy/nkh/oTXctXceRCerA==
+"@foxglove/xmlrpc@^1.1.8":
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/@foxglove/xmlrpc/-/xmlrpc-1.1.8.tgz#95512d38fc0aef32f5de9023c86432f449e385f6"
+  integrity sha512-BrEdB45FJ/Tilk9utSV2Gn1GTB2Z/699UoO7PN/ZyCtENAVv7hK9W3hxxdoGAM+xP9/7bI8HjZxzo5OSwELSmg==
   dependencies:
     "@foxglove/just-fetch" "^1.2.4"
     byte-base64 "^1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -345,9 +345,9 @@
     fetch-blob "^2.1.1"
 
 "@foxglove/rosmsg-serialization@^1.2.3":
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/@foxglove/rosmsg-serialization/-/rosmsg-serialization-1.2.3.tgz#742adc7a322357b0a19aaebb4fe7c2c557f55e92"
-  integrity sha512-wXYqEtcJAXjJEKxxB18tx/3bbI2peQdbqzIWYnCCf9VwVDLk57O/fGqHLJnH5hUH4I37khE/Q0xU/JXSUrp46A==
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@foxglove/rosmsg-serialization/-/rosmsg-serialization-1.3.0.tgz#09df28ada98e117f71ed4f63e4ffee179d8a726e"
+  integrity sha512-8at2IJOU9BrQ4PkDfbBXY5AU0SA9iXTQPfa6M0GEwDajjsl3J7SChJjoncDvNqW5UlcDIiqZg6r2EGs4imVIwQ==
   dependencies:
     "@foxglove/rosmsg" "^2.0.0 || ^3.0.0"
 
@@ -557,9 +557,9 @@
     write-file-atomic "^3.0.0"
 
 "@jest/types@^27.4.0":
-  version "27.4.0"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-27.4.0.tgz#ac5c04d29ce47e0b96439dfd44ec3cd930fc9f86"
-  integrity sha512-jIsLdASXMf8GS7P7oGFGwobNse/6Ewq3GBPHoo0i6XRmja+NrUoDqJm4a1ffF2bHGleKJizxokcp1sCqSktP3g==
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-27.5.1.tgz#3c79ec4a8ba61c170bf937bcf9e98a9df175ec80"
+  integrity sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==
   dependencies:
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/istanbul-reports" "^3.0.0"
@@ -676,7 +676,12 @@
   dependencies:
     "@types/node" "*"
 
-"@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
+"@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz#8467d4b3c087805d63580480890791277ce35c44"
+  integrity sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==
+
+"@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz#4ba8ddb720221f432e443bd5f9117fd22cfd4762"
   integrity sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==
@@ -696,11 +701,11 @@
     "@types/istanbul-lib-report" "*"
 
 "@types/jest@^27.0.3":
-  version "27.0.3"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.0.3.tgz#0cf9dfe9009e467f70a342f0f94ead19842a783a"
-  integrity sha512-cmmwv9t7gBYt7hNKH5Spu7Kuu/DotGa+Ff+JGRKZ4db5eh8PnKS4LuebJ3YLUoyOyIHraTGyULn23YtEAm0VSg==
+  version "27.4.1"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.4.1.tgz#185cbe2926eaaf9662d340cc02e548ce9e11ab6d"
+  integrity sha512-23iPJADSmicDVrWk+HT58LMJtzLAnB2AgIzplQuq/bSrGaxCrlvRFjGbXmamnnk/mAmCdLStiGqggu28ocUyiw==
   dependencies:
-    jest-diff "^27.0.0"
+    jest-matcher-utils "^27.0.0"
     pretty-format "^27.0.0"
 
 "@types/jsdom@^16.2.4":
@@ -723,9 +728,9 @@
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
 "@types/node@*":
-  version "16.11.10"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.10.tgz#2e3ad0a680d96367103d3e670d41c2fed3da61ae"
-  integrity sha512-3aRnHa1KlOEEhJ6+CvyHKK5vE9BcLGjtUpwvqYLRvYNQKMfabu3BwfJaA/SLW8dxe28LsNDjtHwePTuzn3gmOA==
+  version "17.0.23"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.23.tgz#3b41a6e643589ac6442bdbd7a4a3ded62f33f7da"
+  integrity sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==
 
 "@types/parse5@*":
   version "6.0.2"
@@ -748,9 +753,9 @@
   integrity sha512-Y0K95ThC3esLEYD6ZuqNek29lNX2EM1qxV8y2FTLUB0ff5wWrk7az+mLrnNFUnaXcgKye22+sFBRXOgpPILZNg==
 
 "@types/yargs-parser@*":
-  version "20.2.1"
-  resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-20.2.1.tgz#3b9ce2489919d9e4fea439b76916abc34b2df129"
-  integrity sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==
+  version "21.0.0"
+  resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.0.tgz#0c60e537fa790f5f9472ed2776c2b71ec117351b"
+  integrity sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==
 
 "@types/yargs@^16.0.0":
   version "16.0.4"
@@ -1316,10 +1321,10 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
-diff-sequences@^27.4.0:
-  version "27.4.0"
-  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.4.0.tgz#d783920ad8d06ec718a060d00196dfef25b132a5"
-  integrity sha512-YqiQzkrsmHMH5uuh8OdQFU9/ZpADnwzml8z0O5HvRNda+5UZsaX/xN+AAxfR2hWq1Y7HZnAzO9J5lJXOuDz2Ww==
+diff-sequences@^27.4.0, diff-sequences@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.5.1.tgz#eaecc0d327fd68c8d9672a1e64ab8dccb2ef5327"
+  integrity sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -2383,7 +2388,7 @@ jest-config@^27.4.0:
     pretty-format "^27.4.0"
     slash "^3.0.0"
 
-jest-diff@^27.0.0, jest-diff@^27.4.0:
+jest-diff@^27.4.0:
   version "27.4.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.4.0.tgz#d31269e4c070cd794cff756e39ecb4a4010be5cb"
   integrity sha512-fdXgpnyQH4LNSnYgRfHN/g413bqbPspWIAZPlXrdNISehDih1VNDtuRvlzGQJ4Go+fur1HKB2IyI25t6cWi5EA==
@@ -2392,6 +2397,16 @@ jest-diff@^27.0.0, jest-diff@^27.4.0:
     diff-sequences "^27.4.0"
     jest-get-type "^27.4.0"
     pretty-format "^27.4.0"
+
+jest-diff@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.5.1.tgz#a07f5011ac9e6643cf8a95a462b7b1ecf6680def"
+  integrity sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^27.5.1"
+    jest-get-type "^27.5.1"
+    pretty-format "^27.5.1"
 
 jest-docblock@^27.4.0:
   version "27.4.0"
@@ -2437,10 +2452,10 @@ jest-environment-node@^27.4.0:
     jest-mock "^27.4.0"
     jest-util "^27.4.0"
 
-jest-get-type@^27.4.0:
-  version "27.4.0"
-  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-27.4.0.tgz#7503d2663fffa431638337b3998d39c5e928e9b5"
-  integrity sha512-tk9o+ld5TWq41DkK14L4wox4s2D9MtTpKaAVzXfr5CUKm5ZK2ExcaFE0qls2W71zE/6R2TxxrK9w2r6svAFDBQ==
+jest-get-type@^27.4.0, jest-get-type@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-27.5.1.tgz#3cd613c507b0f7ace013df407a1c1cd578bcb4f1"
+  integrity sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==
 
 jest-haste-map@^27.4.0:
   version "27.4.0"
@@ -2493,6 +2508,16 @@ jest-leak-detector@^27.4.0:
   dependencies:
     jest-get-type "^27.4.0"
     pretty-format "^27.4.0"
+
+jest-matcher-utils@^27.0.0:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-27.5.1.tgz#9c0cdbda8245bc22d2331729d1091308b40cf8ab"
+  integrity sha512-z2uTx/T6LBaCoNWNFWwChLBKYxTMcGBRjAt+2SbP929/Fflb9aa5LGma654Rz8z9HLxsrUaYzxE9T/EFIL/PAw==
+  dependencies:
+    chalk "^4.0.0"
+    jest-diff "^27.5.1"
+    jest-get-type "^27.5.1"
+    pretty-format "^27.5.1"
 
 jest-matcher-utils@^27.4.0:
   version "27.4.0"
@@ -3214,12 +3239,11 @@ prettier@2.5.0:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.0.tgz#a6370e2d4594e093270419d9cc47f7670488f893"
   integrity sha512-FM/zAKgWTxj40rH03VxzIPdXmj39SwSjwG0heUcNFwI+EMZJnY93yAiKXM3dObIKAM5TA88werc8T/EwhB45eg==
 
-pretty-format@^27.0.0, pretty-format@^27.4.0:
-  version "27.4.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.4.0.tgz#440a7b86612a18b0865831a6d8585d989a5420e9"
-  integrity sha512-n0QR6hMREfp6nLzfVksXMAfIxk1ffOOfbb/FzKHFmRtn9iJKaZXB8WMzLr8a72IASShEAhqK06nlwp1gVWgqKg==
+pretty-format@^27.0.0, pretty-format@^27.4.0, pretty-format@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
+  integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
   dependencies:
-    "@jest/types" "^27.4.0"
     ansi-regex "^5.0.1"
     ansi-styles "^5.0.0"
     react-is "^17.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -358,10 +358,10 @@
   dependencies:
     md5-typescript "^1.0.5"
 
-"@foxglove/xmlrpc@^1.1.6":
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/@foxglove/xmlrpc/-/xmlrpc-1.1.6.tgz#29e5cf8f38641b8629946381e3cfe22f9c1cab77"
-  integrity sha512-R6JMgJUtltvoyxdjk1zG9C3d092ABAcxRmwjUsdh/xNowNiB9sOKtzn4SctuBFEi+fME6x53SO/2U6hu5rZTPg==
+"@foxglove/xmlrpc@^1.1.7":
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/@foxglove/xmlrpc/-/xmlrpc-1.1.7.tgz#ddda571dcaec73c96d3e718b34ffc14d3374fd0b"
+  integrity sha512-t7g+YgWD2U+AwqfCsPD/IxmJZFxeFF1PMhsjpZUahXCOMHoLbkI4GftPKX/IiFCBD8Cy/nkh/oTXctXceRCerA==
   dependencies:
     "@foxglove/just-fetch" "^1.2.4"
     byte-base64 "^1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -358,10 +358,10 @@
   dependencies:
     md5-typescript "^1.0.5"
 
-"@foxglove/xmlrpc@^1.1.8":
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/@foxglove/xmlrpc/-/xmlrpc-1.1.8.tgz#95512d38fc0aef32f5de9023c86432f449e385f6"
-  integrity sha512-BrEdB45FJ/Tilk9utSV2Gn1GTB2Z/699UoO7PN/ZyCtENAVv7hK9W3hxxdoGAM+xP9/7bI8HjZxzo5OSwELSmg==
+"@foxglove/xmlrpc@^1.1.9":
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/@foxglove/xmlrpc/-/xmlrpc-1.1.9.tgz#15d338f585b538865c0a281d2787a4204721389e"
+  integrity sha512-Lf49vDIh3ewAEtYqI7IeczLfxC4YHRqyavE613KlOoPkBvVrkkjco4lJuFKiSNd0AieJN9D2GV3vZpe5sa2/Cw==
   dependencies:
     "@foxglove/just-fetch" "^1.2.4"
     byte-base64 "^1.1.0"


### PR DESCRIPTION
**Public-Facing Changes**

* roscpp nodes can successfully subscribe to topics advertised by @foxglove/ros1 publishers

**Description**

Previously, our XML-RPC responses were returning `<methodResponse version="1.0">` which is valid XML-RPC but the roscpp XML-RPC client does raw string matching looking for `<methodResponse>`. The @foxglove/xmlrpc library has been updated to be compatible with roscpp.

Additionally, we always send the `Content-Length` header now and no longer use `Transfer-Encoding: chunked` which may or may not have been affecting roscpp clients.

A publishing example has been added to the repo to validate publishing behavior against third-party clients such as rospy / roscpp.