### PR TITLE
Update @foxglove/xmlrpc to 1.2.1 to fix empty string compat with C++ ROS

### DIFF
--- a/examples/ros1-chatter/yarn.lock
+++ b/examples/ros1-chatter/yarn.lock
@@ -34,7 +34,7 @@
   dependencies:
     "@foxglove/rosmsg" "^2.0.0 || ^3.0.0"
     "@foxglove/rosmsg-serialization" "^1.2.3"
-    "@foxglove/xmlrpc" "^1.2.0"
+    "@foxglove/xmlrpc" "^1.2.1"
     eventemitter3 "^4.0.7"
 
 "@foxglove/rosmsg-serialization@^1.2.3":
@@ -51,10 +51,10 @@
   dependencies:
     md5-typescript "^1.0.5"
 
-"@foxglove/xmlrpc@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@foxglove/xmlrpc/-/xmlrpc-1.2.0.tgz#90018a21ab2c897cfbc268d74fe9f7401123926a"
-  integrity sha512-zY1uL0sVaT+8Ekn72eN85n0Q5sMbcOYNjyum2B9Qqvh9w1vty5q6HwO0Gg5HJj65lpiGZTjuEzKM4drEMaY2Ng==
+"@foxglove/xmlrpc@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@foxglove/xmlrpc/-/xmlrpc-1.2.1.tgz#368ece22e71073755735ef81771efbbc1bb6e614"
+  integrity sha512-bZrMh/Hp3QzOhM0oUC5Hn+9VB70cXK0eWJtud647+c1X6q2T89ZlOz4YPSeiIZE2QRMwOhwokJz/T37vfN4LOw==
   dependencies:
     "@foxglove/just-fetch" "^1.2.4"
     byte-base64 "^1.1.0"
@@ -111,9 +111,9 @@
   integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
 
 "@types/node@*":
-  version "17.0.25"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.25.tgz#527051f3c2f77aa52e5dc74e45a3da5fb2301448"
-  integrity sha512-wANk6fBrUwdpY4isjWrKTufkrXdu1D2YHCot2fD/DfWxF5sMrVSA+KN7ydckvaTCh0HiqX9IVl0L5/ZoXg5M7w==
+  version "17.0.27"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.27.tgz#f4df3981ae8268c066e8f49995639f855469081e"
+  integrity sha512-4/Ke7bbWOasuT3kceBZFGakP1dYN2XFd8v2l9bqF2LNWrmeU07JLpp56aEeG6+Q3olqO5TvXpW0yaiYnZJ5CXg==
 
 acorn-walk@^8.1.1:
   version "8.2.0"

--- a/examples/ros1-turtlesim-test/yarn.lock
+++ b/examples/ros1-turtlesim-test/yarn.lock
@@ -34,7 +34,7 @@
   dependencies:
     "@foxglove/rosmsg" "^2.0.0 || ^3.0.0"
     "@foxglove/rosmsg-serialization" "^1.2.3"
-    "@foxglove/xmlrpc" "^1.2.0"
+    "@foxglove/xmlrpc" "^1.2.1"
     eventemitter3 "^4.0.7"
 
 "@foxglove/rosmsg-serialization@^1.2.3":
@@ -51,10 +51,10 @@
   dependencies:
     md5-typescript "^1.0.5"
 
-"@foxglove/xmlrpc@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@foxglove/xmlrpc/-/xmlrpc-1.2.0.tgz#90018a21ab2c897cfbc268d74fe9f7401123926a"
-  integrity sha512-zY1uL0sVaT+8Ekn72eN85n0Q5sMbcOYNjyum2B9Qqvh9w1vty5q6HwO0Gg5HJj65lpiGZTjuEzKM4drEMaY2Ng==
+"@foxglove/xmlrpc@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@foxglove/xmlrpc/-/xmlrpc-1.2.1.tgz#368ece22e71073755735ef81771efbbc1bb6e614"
+  integrity sha512-bZrMh/Hp3QzOhM0oUC5Hn+9VB70cXK0eWJtud647+c1X6q2T89ZlOz4YPSeiIZE2QRMwOhwokJz/T37vfN4LOw==
   dependencies:
     "@foxglove/just-fetch" "^1.2.4"
     byte-base64 "^1.1.0"
@@ -111,9 +111,9 @@
   integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
 
 "@types/node@*":
-  version "17.0.25"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.25.tgz#527051f3c2f77aa52e5dc74e45a3da5fb2301448"
-  integrity sha512-wANk6fBrUwdpY4isjWrKTufkrXdu1D2YHCot2fD/DfWxF5sMrVSA+KN7ydckvaTCh0HiqX9IVl0L5/ZoXg5M7w==
+  version "17.0.27"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.27.tgz#f4df3981ae8268c066e8f49995639f855469081e"
+  integrity sha512-4/Ke7bbWOasuT3kceBZFGakP1dYN2XFd8v2l9bqF2LNWrmeU07JLpp56aEeG6+Q3olqO5TvXpW0yaiYnZJ5CXg==
 
 acorn-walk@^8.1.1:
   version "8.2.0"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "@foxglove/rosmsg": "^2.0.0 || ^3.0.0",
     "@foxglove/rosmsg-serialization": "^1.2.3",
-    "@foxglove/xmlrpc": "^1.2.0",
+    "@foxglove/xmlrpc": "^1.2.1",
     "eventemitter3": "^4.0.7"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -358,10 +358,10 @@
   dependencies:
     md5-typescript "^1.0.5"
 
-"@foxglove/xmlrpc@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@foxglove/xmlrpc/-/xmlrpc-1.2.0.tgz#90018a21ab2c897cfbc268d74fe9f7401123926a"
-  integrity sha512-zY1uL0sVaT+8Ekn72eN85n0Q5sMbcOYNjyum2B9Qqvh9w1vty5q6HwO0Gg5HJj65lpiGZTjuEzKM4drEMaY2Ng==
+"@foxglove/xmlrpc@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@foxglove/xmlrpc/-/xmlrpc-1.2.1.tgz#368ece22e71073755735ef81771efbbc1bb6e614"
+  integrity sha512-bZrMh/Hp3QzOhM0oUC5Hn+9VB70cXK0eWJtud647+c1X6q2T89ZlOz4YPSeiIZE2QRMwOhwokJz/T37vfN4LOw==
   dependencies:
     "@foxglove/just-fetch" "^1.2.4"
     byte-base64 "^1.1.0"


### PR DESCRIPTION
**Public-Facing Changes**

* C++ ROS nodes can successfully connect to @foxglove/ros1 publishers

**Description**

ROS C++ XML-RPC client does not understand `<string/>`, which was causing the `requestTopic` response to fail to parse properly in ROS C++ nodes (among other problems, presumably). The xmlrpc library has been updated to write empty strings as `<string></string>`
