### PR TITLE
TcpClient.ts: allow a connection for "*" datatype

### DIFF
--- a/src/TcpClient.ts
+++ b/src/TcpClient.ts
@@ -196,7 +196,7 @@ export class TcpClient extends EventEmitter<TcpClientEvents> implements Client {
     this._stats.bytesReceived += msgData.byteLength;
 
     // Check the dataType matches
-    if (pub.dataType !== dataType) {
+    if (dataType !== "*" && pub.dataType !== dataType) {
       this._log?.warn?.(
         `tcp client ${this.toString()} attempted to subscribe to topic ${topic} with type "${dataType}", expected "${
           pub.dataType


### PR DESCRIPTION
**Public-Facing Changes**

`@foxglove/ros1` clients can now publish to subscribers that use `"*"` as the subscribed datatype.

# Background

It's possible to create a ROS 1 subscriber that doesn't describe its datatype or md5sum. 
For example, see [this ROS question](https://answers.ros.org/question/36855/is-there-a-way-to-subscribe-to-a-topic-without-setting-the-type/) for a python example, and [nimbro_topic_transport](https://github.com/AIS-Bonn/nimbro_network/tree/master/nimbro_topic_transport) (which uses the [roscpp ShapeShifter class](http://docs.ros.org/en/noetic/api/topic_tools/html/classtopic__tools_1_1ShapeShifter.html)) for a C++ example. 

In that case, the topic subscription provided by the subscriber lists `dataType=*` and `md5sum=*`. `TcpClient.ts` already had a check for allowing `*` for the md5sum but if the dataType is `*` then it will not connect  to the subscriber or publish any messages on the topic.

# Changes

In TcpClient.ts, allow a connection for `"*"` datatype.

# Testing

*Note: I didn't see an obvious place to put a unit test for this... but I'm happy to add one with some guidance.*

To test, create a simple "generic" subscriber like:

```python
#!/usr/bin/env python
from importlib import import_module

import rospy


def chatter_cb(data):
    rospy.logwarn(data)


class GenericMessageSubscriber(object):
    """Subscribe to a topic with unknown datatype.

    Pulled from https://answers.ros.org/question/36855
    """

    def __init__(self, topic_name, callback):
        self._binary_sub = rospy.Subscriber(topic_name,
                                            rospy.AnyMsg,
                                            self.generic_message_callback)
        self._callback = callback

    def generic_message_callback(self, data):
        connection_header = data._connection_header['type'].split('/')
        ros_pkg = connection_header[0] + '.msg'
        msg_type = connection_header[1]
        msg_class = getattr(import_module(ros_pkg), msg_type)
        msg = msg_class().deserialize(data._buff)
        self._callback(msg)


if __name__ == '__main__':
    rospy.init_node('generic_chatter_listener', anonymous=True)
    rospy.loginfo("Listening on /chatter ...")
    GenericMessageSubscriber("chatter", chatter_cb)
    rospy.spin()
```

Then run this node, and run the example in `examples/ros1-chatter`.

Before the fix:

```
mimir:~/dev/foxglove/ros1-jessicaaustin/examples/ros1-chatter$ yarn start
yarn run v1.22.11
$ ts-node src/index.ts
rosfollower listening at http://mimir:42893/
publishing /chatter (std_msgs/String)
registered publisher for /chatter (std_msgs/String)
registered as a publisher for /chatter, 1 current subscriber(s)
tcp client tcpros://127.0.0.1:34812 attempted to subscribe to topic /chatter with type "*", expected "std_msgs/String"
```

After the fix:

```
mimir:~/dev/foxglove/ros1-jessicaaustin/examples/ros1-chatter$ yarn start
yarn run v1.22.11
$ ts-node src/index.ts
rosfollower listening at http://mimir:42087/
publishing /chatter (std_msgs/String)
registered publisher for /chatter (std_msgs/String)
registered as a publisher for /chatter, 1 current subscriber(s)
adding subscriber tcpros://127.0.0.1:46940 (/generic_chatter_listener_18981_1652660369874) to topic /chatter, connectionId 0
```

and the listener:

```
$ ./generic_chatter_listener.py 
[INFO] [1652660369.900235]: Listening on /chatter ...
[WARN] [1652660421.534766]: data: "Hello, world!"
[WARN] [1652660422.479468]: data: "Hello, world!"
[WARN] [1652660423.481318]: data: "Hello, world!"
[WARN] [1652660424.482276]: data: "Hello, world!"
[WARN] [1652660425.484260]: data: "Hello, world!"
[WARN] [1652660426.486071]: data: "Hello, world!"
[WARN] [1652660427.486991]: data: "Hello, world!"
```