### PR TITLE
try to use localAddress for requestTopics response

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   "dependencies": {
     "@foxglove/rosmsg": "^3.1.0",
     "@foxglove/rosmsg-serialization": "^1.5.2",
-    "@foxglove/xmlrpc": "^1.2.1",
+    "@foxglove/xmlrpc": "github:foxglove/xmlrpc#977263a91d49ec2998342688b55854261ff18a9c",
     "eventemitter3": "^4.0.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
   "dependencies": {
     "@foxglove/rosmsg": "^3.1.0",
     "@foxglove/rosmsg-serialization": "^1.5.2",
-    "@foxglove/xmlrpc": "github:foxglove/xmlrpc#977263a91d49ec2998342688b55854261ff18a9c",
-    "eventemitter3": "^4.0.7"
+    "@foxglove/xmlrpc": "^1.3.0",
+    "eventemitter3": "^4.0.7",
+    "ipaddr.js": "^2.0.1"
   }
 }

--- a/src/RosFollower.ts
+++ b/src/RosFollower.ts
@@ -1,4 +1,4 @@
-import { HttpServer, XmlRpcServer, XmlRpcValue } from "@foxglove/xmlrpc";
+import { HttpServer, HttpRequest, XmlRpcServer, XmlRpcValue } from "@foxglove/xmlrpc";
 import { EventEmitter } from "eventemitter3";
 
 import { RosNode } from "./RosNode";
@@ -172,7 +172,11 @@ export class RosFollower extends EventEmitter<RosFollowerEvents> {
     return [1, "", 0];
   };
 
-  requestTopic = async (_: string, args: XmlRpcValue[]): Promise<RosXmlRpcResponse> => {
+  requestTopic = async (
+    _: string,
+    args: XmlRpcValue[],
+    req?: HttpRequest,
+  ): Promise<RosXmlRpcResponse> => {
     const err = CheckArguments(args, ["string", "string", "*"]);
     if (err != null) {
       throw err;
@@ -193,7 +197,8 @@ export class RosFollower extends EventEmitter<RosFollowerEvents> {
       return [0, "cannot receive incoming connections", []];
     }
 
-    const tcp = ["TCPROS", addr.address, addr.port];
+    const address = req.socket?.localAddress ?? addr.address;
+    const tcp = ["TCPROS", address, addr.port];
     return [1, "", tcp];
   };
 }

--- a/src/RosFollower.ts
+++ b/src/RosFollower.ts
@@ -1,9 +1,9 @@
 import { HttpServer, HttpRequest, XmlRpcServer, XmlRpcValue } from "@foxglove/xmlrpc";
 import { EventEmitter } from "eventemitter3";
+import { process as ipaddrProcess } from "ipaddr.js";
 
 import { RosNode } from "./RosNode";
 import { RosXmlRpcResponse } from "./XmlRpcTypes";
-import { process as ipaddrProcess } from "ipaddr.js";
 
 function CheckArguments(args: XmlRpcValue[], expected: string[]): Error | undefined {
   if (args.length !== expected.length) {

--- a/src/RosFollower.ts
+++ b/src/RosFollower.ts
@@ -1,6 +1,6 @@
 import { HttpServer, HttpRequest, XmlRpcServer, XmlRpcValue } from "@foxglove/xmlrpc";
 import { EventEmitter } from "eventemitter3";
-import { process as ipaddrProcess } from "ipaddr.js";
+import ipaddr from "ipaddr.js";
 
 import { RosNode } from "./RosNode";
 import { RosXmlRpcResponse } from "./XmlRpcTypes";
@@ -209,7 +209,7 @@ export class RosFollower extends EventEmitter<RosFollowerEvents> {
     //
     // Note: We still use `addr.port` because we need the _port_ of the TCP server not the HTTP
     // xmlrpc server.
-    const socketLocalAddress = ipaddrProcess(req?.socket?.localAddress ?? addr.address);
+    const socketLocalAddress = ipaddr.process(req?.socket?.localAddress ?? addr.address);
     return [1, "", ["TCPROS", socketLocalAddress.toString(), addr.port]];
   };
 }

--- a/src/RosFollower.ts
+++ b/src/RosFollower.ts
@@ -206,7 +206,10 @@ export class RosFollower extends EventEmitter<RosFollowerEvents> {
     // tpcros destination address increases the chance the client will be able to establish a
     // connection to the publishing node since it has already made a successful xmlrpc request to
     // the same address.
+    //
+    // Note: We still use `addr.port` because we need the _port_ of the TCP server not the HTTP
+    // xmlrpc server.
     const socketLocalAddress = ipaddrProcess(req?.socket?.localAddress ?? addr.address);
-    return [1, "", ["TCPROS", socketLocalAddress.toString(), req?.socket?.localPort ?? addr.port]];
+    return [1, "", ["TCPROS", socketLocalAddress.toString(), addr.port]];
   };
 }

--- a/src/RosNode.test.ts
+++ b/src/RosNode.test.ts
@@ -23,7 +23,7 @@ describe("RosNode", () => {
       rosMasterUri,
       httpServer: new HttpServerNodejs(),
       tcpSocketCreate: TcpSocketNode.Create,
-      tcpServer: await TcpServerNode.Listen({}),
+      tcpServer: await TcpServerNode.Listen({ host: "0.0.0.0" }),
       // log: console,
     });
     nodeA.on("error", (err) => (errA = err));
@@ -35,7 +35,7 @@ describe("RosNode", () => {
       rosMasterUri,
       httpServer: new HttpServerNodejs(),
       tcpSocketCreate: TcpSocketNode.Create,
-      tcpServer: await TcpServerNode.Listen({}),
+      tcpServer: await TcpServerNode.Listen({ host: "0.0.0.0" }),
       // log: console,
     });
     nodeB.on("error", (err) => (errB = err));

--- a/yarn.lock
+++ b/yarn.lock
@@ -559,9 +559,10 @@
   dependencies:
     md5-typescript "^1.0.5"
 
-"@foxglove/xmlrpc@github:foxglove/xmlrpc#977263a91d49ec2998342688b55854261ff18a9c":
-  version "1.2.1"
-  resolved "https://codeload.github.com/foxglove/xmlrpc/tar.gz/977263a91d49ec2998342688b55854261ff18a9c"
+"@foxglove/xmlrpc@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@foxglove/xmlrpc/-/xmlrpc-1.3.0.tgz#37c3054066a0556858244881f6aa631a794cf6fb"
+  integrity sha512-L9S4wrrUh83BycDmQAOTR2oY6PUXW9pCdT8rMIRLkxsdY4hwOpTc9lkeQDg3kO1OjHfiTHfUagvnzXIsMSmsYQ==
   dependencies:
     "@foxglove/just-fetch" "^1.2.4"
     byte-base64 "^1.1.0"
@@ -2294,6 +2295,11 @@ internal-slot@^1.0.3:
     get-intrinsic "^1.1.0"
     has "^1.0.3"
     side-channel "^1.0.4"
+
+ipaddr.js@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-2.0.1.tgz#eca256a7a877e917aeb368b0a7497ddf42ef81c0"
+  integrity sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng==
 
 is-arrayish@^0.2.1:
   version "0.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -559,10 +559,9 @@
   dependencies:
     md5-typescript "^1.0.5"
 
-"@foxglove/xmlrpc@^1.2.1":
+"@foxglove/xmlrpc@github:foxglove/xmlrpc#977263a91d49ec2998342688b55854261ff18a9c":
   version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@foxglove/xmlrpc/-/xmlrpc-1.2.1.tgz#368ece22e71073755735ef81771efbbc1bb6e614"
-  integrity sha512-bZrMh/Hp3QzOhM0oUC5Hn+9VB70cXK0eWJtud647+c1X6q2T89ZlOz4YPSeiIZE2QRMwOhwokJz/T37vfN4LOw==
+  resolved "https://codeload.github.com/foxglove/xmlrpc/tar.gz/977263a91d49ec2998342688b55854261ff18a9c"
   dependencies:
     "@foxglove/just-fetch" "^1.2.4"
     byte-base64 "^1.1.0"


### PR DESCRIPTION
**User-Facing Changes**
Improved handling of subscription requests from remote and local nodes.

**Description**
ROS subscriber clients use the address and port response arguments to determine where to establish a connection to receive messages. ROS clients may be on the local machine or on remote hosts. To better support subscribers on local or remote hosts, we attempt to use the socket localAddress of the xmlrpc request if it present. Since the xmlrpc server and tcp socket publishers are launched within the same node, echoing the localAddress back as the tpcros destination address increases the chance the client will be able to establish a connection to the publishing node since it has already made a successful xmlrpc request to the same address.
