### PR TITLE
Remove uses of LazyMessageReader

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/ros1",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Standalone TypeScript implementation of the ROS 1 (Robot Operating System) protocol with a pluggable transport layer",
   "license": "MIT",
   "keywords": [

--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -1,5 +1,5 @@
 import { MessageDefinition } from "@foxglove/message-definition";
-import { LazyMessageReader } from "@foxglove/rosmsg-serialization";
+import { MessageReader } from "@foxglove/rosmsg-serialization";
 
 export interface ConnectionStats {
   bytesSent: number;
@@ -15,7 +15,7 @@ export interface Connection {
     listener: (
       header: Map<string, string>,
       msgDef: MessageDefinition[],
-      msgReader: LazyMessageReader,
+      msgReader: MessageReader,
     ) => void,
   ): this;
   on(eventName: "message", listener: (msg: unknown, data: Uint8Array) => void): this;
@@ -33,7 +33,7 @@ export interface Connection {
 
   messageDefinition(): MessageDefinition[];
 
-  messageReader(): LazyMessageReader | undefined;
+  messageReader(): MessageReader | undefined;
 
   close(): void;
 

--- a/src/Subscription.ts
+++ b/src/Subscription.ts
@@ -1,5 +1,5 @@
 import { MessageDefinition } from "@foxglove/message-definition";
-import { LazyMessageReader } from "@foxglove/rosmsg-serialization";
+import { MessageReader } from "@foxglove/rosmsg-serialization";
 import { EventEmitter } from "eventemitter3";
 
 import { Connection } from "./Connection";
@@ -36,7 +36,7 @@ export interface SubscriptionEvents {
   header: (
     header: Map<string, string>,
     msgDef: MessageDefinition[],
-    msgReader: LazyMessageReader,
+    msgReader: MessageReader,
   ) => void;
   message: (msg: unknown, data: Uint8Array, publisher: PublisherLink) => void;
   error: (err: Error) => void;

--- a/src/TcpConnection.test.ts
+++ b/src/TcpConnection.test.ts
@@ -85,9 +85,7 @@ describe("TcpConnection", () => {
       connection.on("error", reject);
     });
     await socket.connect();
-    const msg = (await p) as { toJSON: () => unknown };
-
-    expect(msg.toJSON()).toEqual({ b: 255, g: 86, r: 69 });
+    await expect(p).resolves.toEqual({ b: 255, g: 86, r: 69 });
 
     connection.close();
     await new Promise<void>((resolve, reject) =>


### PR DESCRIPTION
### Public-Facing Changes

Received messages are now fully deserialized as JS objects rather than using `@foxglove/rosmsg-serialization`'s `LazyMessageReader`.

### Description

Resolves [FG-5047](https://linear.app/foxglove/issue/FG-5047/remove-lazymessagereader-uses-from-foxgloveros1)
Ultimately we did not find that lazy reading provided a performance benefit that justifies the downstream complexity of inconsistencies between data sources. The Studio app will likely need a deeper architectural change to support more efficient message processing across worker threads, rather than just swapping out objects for lazy objects.